### PR TITLE
Fix creating links when they already exist and custom schedule

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,12 +3,27 @@ default['certbot']['bin']['group'] = "root"
 default['certbot']['bin']['mode'] = 0755
 default['certbot']['bin']['path'] = "/usr/local/bin/certbot-auto"
 default['certbot']['bin']['download_uri'] = "https://dl.eff.org/certbot-auto"
-default['certbot']['webroot'] = ""
+
+# if true, will use certbot's standalone server, otherwise will use webroot
 default['certbot']['standalone'] = true
+
+# path to the webroot directory (--webroot-path)
+default['certbot']['webroot'] = ""
+
+# list of domains to be registered
 default['certbot']['domains'] = []
+
+# pre and post hooks, e.g. "service apache2 stop"
 default['certbot']['pre_hook'] = ""
 default['certbot']['post_hook'] = ""
+
+# full paths to the certificate files
+# will create symbolic links in these paths pointing to the certificates in letsencrypt folders
 default['certbot']['cert_path'] = ""
 default['certbot']['chain_path'] = ""
 default['certbot']['fullchain_path'] = ""
 default['certbot']['key_path'] = ""
+
+# two random hours of the day at any random minute within it
+default['certbot']['schedule']["hour"] = [ Random.new.rand(0..11) ].map{ |n| [n, n+12] }.join(",")
+default['certbot']['schedule']["minute"] = Random.new.rand(0..59).to_s

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,10 +56,7 @@ ruby_block "create symlinks" do
       FileUtils.mkdir_p File.dirname(dst)
       letsencrypt_certs = Dir.glob("/etc/letsencrypt/live/*").map{ |d| File.basename(d) }
       intersection = domains & letsencrypt_certs
-      if !intersection.empty?
-        FileUtils.rm_f dst
-        FileUtils.ln_s "/etc/letsencrypt/live/#{intersection.first}/#{src}", dst
-      end
+      FileUtils.ln_s "/etc/letsencrypt/live/#{intersection.first}/#{src}", dst, force: true if ! intersection.empty?
     end
   end
   action :run

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,8 +39,8 @@ renew_cmd << "--no-self-upgrade"
 renew_cmd << "--quiet"
 
 cron "auto renew let's encrypt certificate" do
-  hour [ Random.new.rand(0..11) ].map{ |n| [n, n+12] }.join(",")
-  minute Random.new.rand(0..59).to_s
+  hour node['certbot']['schedule']["hour"]
+  minute node['certbot']['schedule']["minute"]
   command renew_cmd.join(" ")
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,7 +56,10 @@ ruby_block "create symlinks" do
       FileUtils.mkdir_p File.dirname(dst)
       letsencrypt_certs = Dir.glob("/etc/letsencrypt/live/*").map{ |d| File.basename(d) }
       intersection = domains & letsencrypt_certs
-      FileUtils.ln_s "/etc/letsencrypt/live/#{intersection.first}/#{src}", dst if ! intersection.empty?
+      if !intersection.empty?
+        FileUtils.rm_f dst
+        FileUtils.ln_s "/etc/letsencrypt/live/#{intersection.first}/#{src}", dst
+      end
     end
   end
   action :run


### PR DESCRIPTION
- Force links to be recreated, so it doesn't break if they already exist
- Allow cron's schedule to be configured
