### PR TITLE
Fix renewal command and send its output to a log file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,8 @@ default['certbot']['bin']['mode'] = 0755
 default['certbot']['bin']['path'] = "/usr/local/bin/certbot-auto"
 default['certbot']['bin']['download_uri'] = "https://dl.eff.org/certbot-auto"
 
+default['certbot']['log'] = "/var/log/certbot-auto.log"
+
 # if true, will use certbot's standalone server, otherwise will use webroot
 default['certbot']['standalone'] = true
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,13 +30,15 @@ execute "install certbot" do
   action :run
 end
 
-renew_cmd = [ node['certbot']['bin']['path'], "renew" ]
+renew_cmd = [ "PATH=\"/sbin:/bin:$PATH\"", node['certbot']['bin']['path'], "renew" ]
 renew_cmd << "--standalone" if node['certbot']['standalone']
 renew_cmd << "--webroot #{node['certbot']['webroot']}" if node['certbot']['webroot'].to_s != ''
 renew_cmd << "--pre-hook \"#{node['certbot']['pre_hook']}\"" if node['certbot']['pre_hook'].to_s != ''
 renew_cmd << "--post-hook \"#{node['certbot']['post_hook']}\"" if node['certbot']['post_hook'].to_s != ''
 renew_cmd << "--no-self-upgrade"
-renew_cmd << "--quiet"
+renew_cmd << "--non-interactive"
+renew_cmd << "> #{node['certbot']['log']} 2>&1"
+Chef::Log.info "Configuring cron to run: #{renew_cmd.join(" ")}"
 
 cron "auto renew let's encrypt certificate" do
   hour node['certbot']['schedule']["hour"]


### PR DESCRIPTION
Was failing because it tried something with apt-get and failed to find
some executables because they were not in the path. Setting the PATH
fixed it.

The log file keeps the output from the last execution.

Resolves #3.
